### PR TITLE
Fix build error by removing plugin line

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,3 @@ author:
     - label: "GitHub"
       url: "https://github.com/yourusername"
 
-# Plugins (Minimal Mistakes requirement)
-plugins:
-  - jekyll-include-cache


### PR DESCRIPTION
## Summary
- remove `jekyll-include-cache` from `_config.yml`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6840d278715483299ca4df26b565eff7