### PR TITLE
Add jekyll-include-cache plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,5 @@ author:
     - label: "GitHub"
       url: "https://github.com/yourusername"
 
+plugins:
+  - jekyll-include-cache


### PR DESCRIPTION
## Summary
- enable include caching for Jekyll site by adding `jekyll-include-cache` to `_config.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840dddfa1908329bd5581ae395898ad